### PR TITLE
feat: add list_credentials tool to expose available n8n credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "n8n-workflow-builder-mcp",
-    "version": "0.1.8",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "n8n-workflow-builder-mcp",
-            "version": "0.1.8",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.11.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ import { loadKnownNodeBaseTypes, normalizeNodeTypeAndVersion, isNodeTypeSupporte
 import { materializeIfConfigured } from './utils/nodesDb';
 import * as connectMainChain from './mcp/tools/connectMainChain';
 import * as listTemplateExamples from './mcp/tools/listTemplateExamples';
+import * as deployWorkflow from './mcp/tools/deployWorkflow';
+import * as updateRemoteWorkflow from './mcp/tools/updateRemoteWorkflow';
+import * as activateWorkflow from './mcp/tools/activateWorkflow';
+import * as deactivateWorkflow from './mcp/tools/deactivateWorkflow';
+import * as deleteRemoteWorkflow from './mcp/tools/deleteRemoteWorkflow';
+import * as listRemoteWorkflows from './mcp/tools/listRemoteWorkflows';
 
 // Log initial workspace
 console.error(`[DEBUG] Default workspace directory: ${getWorkspaceDir()}`);
@@ -2982,6 +2988,50 @@ server.tool(
     listTemplateExamples.description,
     listTemplateExamples.paramsSchema.shape,
     listTemplateExamples.handler
+);
+
+// --- Remote deployment tools (n8n REST API) ---
+
+server.tool(
+    deployWorkflow.toolName,
+    deployWorkflow.description,
+    deployWorkflow.paramsSchema.shape,
+    deployWorkflow.handler
+);
+
+server.tool(
+    updateRemoteWorkflow.toolName,
+    updateRemoteWorkflow.description,
+    updateRemoteWorkflow.paramsSchema.shape,
+    updateRemoteWorkflow.handler
+);
+
+server.tool(
+    activateWorkflow.toolName,
+    activateWorkflow.description,
+    activateWorkflow.paramsSchema.shape,
+    activateWorkflow.handler
+);
+
+server.tool(
+    deactivateWorkflow.toolName,
+    deactivateWorkflow.description,
+    deactivateWorkflow.paramsSchema.shape,
+    deactivateWorkflow.handler
+);
+
+server.tool(
+    deleteRemoteWorkflow.toolName,
+    deleteRemoteWorkflow.description,
+    deleteRemoteWorkflow.paramsSchema.shape,
+    deleteRemoteWorkflow.handler
+);
+
+server.tool(
+    listRemoteWorkflows.toolName,
+    listRemoteWorkflows.description,
+    listRemoteWorkflows.paramsSchema.shape,
+    listRemoteWorkflows.handler
 );
 
 // Create and configure the transport

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import * as activateWorkflow from './mcp/tools/activateWorkflow';
 import * as deactivateWorkflow from './mcp/tools/deactivateWorkflow';
 import * as deleteRemoteWorkflow from './mcp/tools/deleteRemoteWorkflow';
 import * as listRemoteWorkflows from './mcp/tools/listRemoteWorkflows';
+import * as listCredentials from './mcp/tools/listCredentials';
 
 // Log initial workspace
 console.error(`[DEBUG] Default workspace directory: ${getWorkspaceDir()}`);
@@ -3032,6 +3033,13 @@ server.tool(
     listRemoteWorkflows.description,
     listRemoteWorkflows.paramsSchema.shape,
     listRemoteWorkflows.handler
+);
+
+server.tool(
+    listCredentials.toolName,
+    listCredentials.description,
+    listCredentials.paramsSchema.shape,
+    listCredentials.handler
 );
 
 // Create and configure the transport

--- a/src/mcp/tools/activateWorkflow.ts
+++ b/src/mcp/tools/activateWorkflow.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { activateWorkflow as activate } from '../../utils/n8nClient.js';
+
+export const toolName = 'activate_workflow';
+export const description = 'Activate a workflow on the n8n instance so it runs in production (responds to triggers).';
+
+export const paramsSchema = z.object({
+    remote_workflow_id: z.string().describe('ID of the workflow on the n8n instance to activate'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        const result = await activate(params.remote_workflow_id);
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    remoteWorkflowId: result.id,
+                    name: result.name,
+                    active: result.active,
+                }),
+            }],
+        };
+    } catch (error: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: `Failed to activate workflow: ${error.message}` }) }] };
+    }
+}

--- a/src/mcp/tools/deactivateWorkflow.ts
+++ b/src/mcp/tools/deactivateWorkflow.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { deactivateWorkflow as deactivate } from '../../utils/n8nClient.js';
+
+export const toolName = 'deactivate_workflow';
+export const description = 'Deactivate a workflow on the n8n instance so it stops responding to triggers.';
+
+export const paramsSchema = z.object({
+    remote_workflow_id: z.string().describe('ID of the workflow on the n8n instance to deactivate'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        const result = await deactivate(params.remote_workflow_id);
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    remoteWorkflowId: result.id,
+                    name: result.name,
+                    active: result.active,
+                }),
+            }],
+        };
+    } catch (error: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: `Failed to deactivate workflow: ${error.message}` }) }] };
+    }
+}

--- a/src/mcp/tools/deleteRemoteWorkflow.ts
+++ b/src/mcp/tools/deleteRemoteWorkflow.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { deleteWorkflow } from '../../utils/n8nClient.js';
+
+export const toolName = 'delete_remote_workflow';
+export const description = 'Permanently delete a workflow from the n8n instance.';
+
+export const paramsSchema = z.object({
+    remote_workflow_id: z.string().describe('ID of the workflow on the n8n instance to delete'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        await deleteWorkflow(params.remote_workflow_id);
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    remoteWorkflowId: params.remote_workflow_id,
+                    deleted: true,
+                }),
+            }],
+        };
+    } catch (error: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: `Failed to delete remote workflow: ${error.message}` }) }] };
+    }
+}

--- a/src/mcp/tools/deployWorkflow.ts
+++ b/src/mcp/tools/deployWorkflow.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import fs from 'fs/promises';
+import { resolveWorkflowPath, tryDetectWorkspaceForName } from '../../utils/workspace.js';
+import { postWorkflow } from '../../utils/n8nClient.js';
+
+export const toolName = 'deploy_workflow';
+export const description = 'Deploy a locally-built workflow to the n8n instance. Reads the JSON from workflow_data/, strips internal fields, and POSTs it to the n8n REST API.';
+
+export const paramsSchema = z.object({
+    workflow_name: z.string().describe('Name of the local workflow to deploy'),
+    workflow_path: z.string().optional().describe('Optional direct path to the workflow JSON file'),
+    activate: z.boolean().optional().default(false).describe('Activate the workflow immediately after deployment'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        let filePath = resolveWorkflowPath(params.workflow_name, params.workflow_path);
+        try {
+            if (!params.workflow_path) {
+                await fs.access(filePath).catch(async () => {
+                    const detected = await tryDetectWorkspaceForName(params.workflow_name);
+                    if (detected) filePath = detected;
+                });
+            }
+        } catch { /* ignore */ }
+
+        const raw = await fs.readFile(filePath, 'utf8');
+        const workflow = JSON.parse(raw);
+
+        const { name, nodes, connections, settings } = workflow;
+        if (!name || !nodes) {
+            return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: 'Workflow JSON is missing required fields (name, nodes)' }) }] };
+        }
+
+        const payload: any = { name, nodes, connections: connections || {}, settings: settings || {} };
+        if (params.activate) {
+            payload.active = true;
+        }
+
+        const result = await postWorkflow(payload);
+
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    remoteWorkflowId: result.id,
+                    name: result.name,
+                    active: result.active,
+                    localPath: filePath,
+                    recommended_next_step: result.active
+                        ? 'Workflow is deployed and active.'
+                        : "Call 'activate_workflow' with the remoteWorkflowId to activate it.",
+                }),
+            }],
+        };
+    } catch (error: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: `Failed to deploy workflow: ${error.message}` }) }] };
+    }
+}

--- a/src/mcp/tools/listCredentials.ts
+++ b/src/mcp/tools/listCredentials.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import { listCredentials as fetchCredentials } from '../../utils/n8nClient.js';
+
+export const toolName = 'list_credentials';
+export const description =
+    'List credentials available on the n8n instance. Returns credential names and types only — no sensitive data is exposed. Useful for knowing which credentials exist when building workflows that require authentication.';
+
+export const paramsSchema = z.object({
+    type: z
+        .string()
+        .optional()
+        .describe('Filter by credential type (e.g. "slackApi", "httpBasicAuth"). Omit to list all.'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        const result = await fetchCredentials();
+        let credentials = result.data || result;
+
+        if (!Array.isArray(credentials)) {
+            credentials = [];
+        }
+
+        if (params.type) {
+            const filterType = params.type.toLowerCase();
+            credentials = credentials.filter(
+                (c: any) => c.type && c.type.toLowerCase() === filterType,
+            );
+        }
+
+        const summary = credentials.map((c: any) => ({
+            id: c.id,
+            name: c.name,
+            type: c.type,
+            createdAt: c.createdAt,
+            updatedAt: c.updatedAt,
+        }));
+
+        return {
+            content: [
+                {
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                        success: true,
+                        count: summary.length,
+                        credentials: summary,
+                    }),
+                },
+            ],
+        };
+    } catch (error: any) {
+        return {
+            content: [
+                {
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                        success: false,
+                        error: `Failed to list credentials: ${error.message}`,
+                    }),
+                },
+            ],
+        };
+    }
+}

--- a/src/mcp/tools/listRemoteWorkflows.ts
+++ b/src/mcp/tools/listRemoteWorkflows.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { listWorkflows } from '../../utils/n8nClient.js';
+
+export const toolName = 'list_remote_workflows';
+export const description = 'List workflows deployed on the n8n instance.';
+
+export const paramsSchema = z.object({
+    limit: z.number().optional().default(100).describe('Maximum number of workflows to return'),
+    active_only: z.boolean().optional().default(false).describe('Only return active workflows'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        const result = await listWorkflows(params.limit);
+        let workflows = result.data || result;
+
+        if (params.active_only && Array.isArray(workflows)) {
+            workflows = workflows.filter((w: any) => w.active === true);
+        }
+
+        const summary = Array.isArray(workflows)
+            ? workflows.map((w: any) => ({
+                id: w.id,
+                name: w.name,
+                active: w.active,
+                createdAt: w.createdAt,
+                updatedAt: w.updatedAt,
+            }))
+            : workflows;
+
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    count: Array.isArray(summary) ? summary.length : 0,
+                    workflows: summary,
+                }),
+            }],
+        };
+    } catch (error: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: `Failed to list remote workflows: ${error.message}` }) }] };
+    }
+}

--- a/src/mcp/tools/updateRemoteWorkflow.ts
+++ b/src/mcp/tools/updateRemoteWorkflow.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import fs from 'fs/promises';
+import { resolveWorkflowPath, tryDetectWorkspaceForName } from '../../utils/workspace.js';
+import { putWorkflow } from '../../utils/n8nClient.js';
+
+export const toolName = 'update_remote_workflow';
+export const description = 'Update an existing workflow on the n8n instance with the local version. Reads the JSON from workflow_data/, strips internal fields, and PUTs it to the n8n REST API.';
+
+export const paramsSchema = z.object({
+    workflow_name: z.string().describe('Name of the local workflow to push'),
+    remote_workflow_id: z.string().describe('ID of the workflow on the n8n instance to update'),
+    workflow_path: z.string().optional().describe('Optional direct path to the workflow JSON file'),
+});
+
+export type Params = z.infer<typeof paramsSchema>;
+
+export async function handler(params: Params, _extra: any) {
+    try {
+        let filePath = resolveWorkflowPath(params.workflow_name, params.workflow_path);
+        try {
+            if (!params.workflow_path) {
+                await fs.access(filePath).catch(async () => {
+                    const detected = await tryDetectWorkspaceForName(params.workflow_name);
+                    if (detected) filePath = detected;
+                });
+            }
+        } catch { /* ignore */ }
+
+        const raw = await fs.readFile(filePath, 'utf8');
+        const workflow = JSON.parse(raw);
+
+        const { name, nodes, connections, settings } = workflow;
+        if (!name || !nodes) {
+            return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: 'Workflow JSON is missing required fields (name, nodes)' }) }] };
+        }
+
+        const payload = { name, nodes, connections: connections || {}, settings: settings || {} };
+        const result = await putWorkflow(params.remote_workflow_id, payload);
+
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({
+                    success: true,
+                    remoteWorkflowId: result.id,
+                    name: result.name,
+                    active: result.active,
+                    localPath: filePath,
+                }),
+            }],
+        };
+    } catch (error: any) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: `Failed to update remote workflow: ${error.message}` }) }] };
+    }
+}

--- a/src/utils/n8nClient.ts
+++ b/src/utils/n8nClient.ts
@@ -1,0 +1,64 @@
+const N8N_API_URL = process.env.N8N_API_URL || '';
+const N8N_API_KEY = process.env.N8N_API_KEY || '';
+
+function getBaseUrl(): string {
+    if (!N8N_API_URL) {
+        throw new Error('N8N_API_URL environment variable is not set');
+    }
+    return N8N_API_URL.replace(/\/api\/?$/, '').replace(/\/$/, '');
+}
+
+function getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+    };
+    if (N8N_API_KEY) {
+        headers['X-N8N-API-KEY'] = N8N_API_KEY;
+    }
+    return headers;
+}
+
+async function request(method: string, path: string, body?: object): Promise<any> {
+    const url = `${getBaseUrl()}/api/v1${path}`;
+    const response = await fetch(url, {
+        method,
+        headers: getHeaders(),
+        ...(body && { body: JSON.stringify(body) }),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+        const message = (data as any)?.message || response.statusText;
+        throw new Error(`n8n API ${method} ${path} failed (${response.status}): ${message}`);
+    }
+    return data;
+}
+
+export async function postWorkflow(body: object): Promise<any> {
+    return request('POST', '/workflows', body);
+}
+
+export async function putWorkflow(id: string, body: object): Promise<any> {
+    return request('PUT', `/workflows/${id}`, body);
+}
+
+export async function deleteWorkflow(id: string): Promise<any> {
+    return request('DELETE', `/workflows/${id}`);
+}
+
+export async function activateWorkflow(id: string): Promise<any> {
+    return request('POST', `/workflows/${id}/activate`);
+}
+
+export async function deactivateWorkflow(id: string): Promise<any> {
+    return request('POST', `/workflows/${id}/deactivate`);
+}
+
+export async function listWorkflows(limit?: number): Promise<any> {
+    const query = limit ? `?limit=${limit}` : '';
+    return request('GET', `/workflows${query}`);
+}
+
+export async function getWorkflow(id: string): Promise<any> {
+    return request('GET', `/workflows/${id}`);
+}

--- a/src/utils/n8nClient.ts
+++ b/src/utils/n8nClient.ts
@@ -62,3 +62,7 @@ export async function listWorkflows(limit?: number): Promise<any> {
 export async function getWorkflow(id: string): Promise<any> {
     return request('GET', `/workflows/${id}`);
 }
+
+export async function listCredentials(): Promise<any> {
+    return request('GET', '/credentials');
+}


### PR DESCRIPTION
## Summary
- Adds a new `list_credentials` MCP tool that queries the n8n REST API (`GET /api/v1/credentials`) to return credential metadata (id, name, type, timestamps)
- No sensitive credential data is ever fetched or exposed — only names and types
- Supports an optional `type` filter parameter to narrow results by credential type (e.g. `slackApi`, `httpBasicAuth`)

## Changes
- **`src/utils/n8nClient.ts`** — added `listCredentials()` API client function
- **`src/mcp/tools/listCredentials.ts`** — new modular tool following existing patterns
- **`src/index.ts`** — imported and registered the new tool

## Test plan
- [ ] Verify `list_credentials` returns credentials from a connected n8n instance
- [ ] Verify filtering by `type` param works correctly
- [ ] Verify no sensitive credential data appears in the response
- [ ] Confirm graceful error handling when n8n API is unreachable or API key is missing


Made with [Cursor](https://cursor.com)